### PR TITLE
Fix image viewer uri and individual image support

### DIFF
--- a/control_panel_app/lib/features/chat/presentation/widgets/expandable_image_viewer.dart
+++ b/control_panel_app/lib/features/chat/presentation/widgets/expandable_image_viewer.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:photo_view/photo_view.dart';
 import 'package:photo_view/photo_view_gallery.dart';
+import '../../../../core/widgets/cached_image_widget.dart';
 import '../../domain/entities/attachment.dart';
 
 class ExpandableImageViewer extends StatefulWidget {
@@ -59,8 +60,13 @@ class _ExpandableImageViewerState extends State<ExpandableImageViewer> {
               onPageChanged: (index) => setState(() => _currentIndex = index),
               builder: (context, index) {
                 final image = widget.images[index];
-                return PhotoViewGalleryPageOptions(
-                  imageProvider: NetworkImage(image.fileUrl),
+                return PhotoViewGalleryPageOptions.customChild(
+                  child: CachedImageWidget(
+                    imageUrl: image.fileUrl,
+                    fit: BoxFit.contain,
+                    removeContainer: true,
+                  ),
+                  initialScale: PhotoViewComputedScale.contained,
                   minScale: PhotoViewComputedScale.contained,
                   maxScale: PhotoViewComputedScale.covered * 3.0,
                   heroAttributes: PhotoViewHeroAttributes(tag: image.id),

--- a/control_panel_app/lib/features/chat/presentation/widgets/whatsapp_style_image_grid.dart
+++ b/control_panel_app/lib/features/chat/presentation/widgets/whatsapp_style_image_grid.dart
@@ -53,13 +53,21 @@ class WhatsAppStyleImageGrid extends StatelessWidget {
   }
 
   Widget _buildSingleImage(Attachment image) {
-    // Keep a visually pleasant default ratio, but remove extra container to avoid inner margins.
+    // Keep a visually pleasant default ratio and ensure tap opens viewer.
     return AspectRatio(
       aspectRatio: 4 / 3,
-      child: CachedImageWidget(
-        imageUrl: image.fileUrl,
-        fit: BoxFit.cover,
-        removeContainer: true,
+      child: Builder(
+        builder: (context) => GestureDetector(
+          onTap: () {
+            HapticFeedback.lightImpact();
+            _openImageViewer(context, 0);
+          },
+          child: CachedImageWidget(
+            imageUrl: image.fileUrl,
+            fit: BoxFit.cover,
+            removeContainer: true,
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
Fix `ArgumentError` in `ExpandableImageViewer` by resolving relative image URLs and enable single image tap to open the viewer.

The `ArgumentError` was caused by `NetworkImage` attempting to load relative URLs as `file:///` URIs. This is resolved by using `CachedImageWidget` which correctly resolves relative URLs to absolute ones and includes necessary authentication headers. Additionally, the image viewer now opens for single images by adding a `GestureDetector` to the `_buildSingleImage` widget.

---
<a href="https://cursor.com/background-agent?bcId=bc-d0d60c41-6f88-4409-bcba-219a6c87ce7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d0d60c41-6f88-4409-bcba-219a6c87ce7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

