### PR TITLE
Fix chat errors and backend sync

### DIFF
--- a/control_panel_app/lib/features/chat/presentation/bloc/chat_bloc.dart
+++ b/control_panel_app/lib/features/chat/presentation/bloc/chat_bloc.dart
@@ -781,7 +781,6 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
             );
             event.onProgress?.call(sent, total);
           },
-          replyToMessageId: event.replyToMessageId,
         ),
       );
 
@@ -1707,7 +1706,16 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
     emit(currentState.copyWith(settings: updatedSettings));
 
     final result = await updateChatSettingsUseCase(
-      UpdateChatSettingsParams(settings: updatedSettings),
+      UpdateChatSettingsParams(
+        notificationsEnabled: updatedSettings.notificationsEnabled,
+        soundEnabled: updatedSettings.soundEnabled,
+        showReadReceipts: updatedSettings.showReadReceipts,
+        showTypingIndicator: updatedSettings.showTypingIndicator,
+        theme: updatedSettings.theme,
+        fontSize: updatedSettings.fontSize,
+        autoDownloadMedia: updatedSettings.autoDownloadMedia,
+        backupMessages: updatedSettings.backupMessages,
+      ),
     );
 
     await result.fold(


### PR DESCRIPTION
Fix two Flutter analyzer errors by correcting parameter usage in `chat_bloc.dart`.

The `UploadAttachmentParams` call was updated to remove the unsupported `replyToMessageId` parameter, and the `UpdateChatSettingsParams` call was refactored to pass individual settings fields instead of a nested `settings` object, aligning with the use case's expected signature.

---
<a href="https://cursor.com/background-agent?bcId=bc-7251fbd9-776e-4b1a-8cbd-6795ce695211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7251fbd9-776e-4b1a-8cbd-6795ce695211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

